### PR TITLE
Added default logger for when logging is enabled but logger is not specified.

### DIFF
--- a/query_string_parser.go
+++ b/query_string_parser.go
@@ -29,6 +29,7 @@ package querystr
 import (
 	"fmt"
 	"log"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -43,27 +44,35 @@ type QueryStringOptions struct {
 	logger      *log.Logger
 }
 
+var defaultLogger = log.New(os.Stderr, "", log.LstdFlags)
+
+// DefaultOptions creates default options with debug features disabled
 func DefaultOptions() QueryStringOptions {
 	return QueryStringOptions{
 		dateFormat: time.RFC3339,
+		logger:     defaultLogger,
 	}
 }
 
+// WithDebugParser will make parser print debug messages to logger in options or stderr by default
 func (o QueryStringOptions) WithDebugParser(debug bool) QueryStringOptions {
 	o.debugParser = debug
 	return o
 }
 
+// WithDebugLexer will make lexer print debug messages to logger in options or stderr by default
 func (o QueryStringOptions) WithDebugLexer(debug bool) QueryStringOptions {
 	o.debugLexer = debug
 	return o
 }
 
+// WithDateFormat changes the default date format (RFC 3339) to the specified one
 func (o QueryStringOptions) WithDateFormat(dateFormat string) QueryStringOptions {
 	o.dateFormat = dateFormat
 	return o
 }
 
+// WithLogger changes the log destination to the specified one, default is os.Stderr
 func (o QueryStringOptions) WithLogger(logger *log.Logger) QueryStringOptions {
 	o.logger = logger
 	return o

--- a/query_string_parser_test.go
+++ b/query_string_parser_test.go
@@ -15,6 +15,7 @@
 package querystr
 
 import (
+	"io/ioutil"
 	"reflect"
 	"strings"
 	"testing"
@@ -417,6 +418,20 @@ func TestQuerySyntaxParserInvalid(t *testing.T) {
 		if err == nil {
 			t.Errorf("expected error, got nil for `%s`", test.input)
 		}
+	}
+}
+
+func TestParserDebugWithNoLogger(t *testing.T) {
+	// don't print logs in tests
+	defaultLogger.SetOutput(ioutil.Discard)
+
+	r, err := ParseQueryString("text", DefaultOptions().WithDebugParser(true))
+	if err != nil {
+		t.Errorf("unexpected error: %+v", err)
+	}
+	expectedQuery := bluge.NewBooleanQuery().AddShould(bluge.NewMatchQuery("text"))
+	if !reflect.DeepEqual(r, expectedQuery) {
+		t.Error("unexpected query returned")
 	}
 }
 


### PR DESCRIPTION
I've added a default logger in this commit, a test to validate that the default logger does not cause nil dereference (as in #1)
And I've also added some docs to clarify the options usage.

